### PR TITLE
resolved overlapping sidebar on contact us section

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,13 @@
+<!-- Sidebar -->
+<section id="sidebar">
+	<div class="inner">
+		<nav>
+			<ul>
+				<li><a href="#intro">Welcome</a></li>
+				<li><a href="#one">Who we are</a></li>
+				<li><a href="#two">What we do</a></li>
+				<li><a href="#three">Get in touch</a></li>
+			</ul>
+		</nav>
+	</div>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,11 @@
 {% include head.html %}
 <body>
 {% include header.html %}
+{% include sidebar.html %}
+<!-- Wrapper -->
+<div id="wrapper">
 {{ content }}
 {% include footer.html %}
+</div>
 </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -2,24 +2,6 @@
 layout: default
 title: Hyperspace by HTML5 UP
 ---
-
-<!-- Sidebar -->
-<section id="sidebar">
-	<div class="inner">
-		<nav>
-			<ul>
-				<li><a href="#intro">Welcome</a></li>
-				<li><a href="#one">Who we are</a></li>
-				<li><a href="#two">What we do</a></li>
-				<li><a href="#three">Get in touch</a></li>
-			</ul>
-		</nav>
-	</div>
-</section>
-
-<!-- Wrapper -->
-<div id="wrapper">
-
 <!-- Intro -->
 <section id="intro" class="wrapper style1 fullscreen fade-up">
 	<div class="inner">


### PR DESCRIPTION
On windows firefox, the sidebar would overlap with contact us section and
footer. Moving sidebar into _includes and applying wrapper div in
default.html resolves this